### PR TITLE
Recycler and Mass fab fix

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
@@ -20,6 +20,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.cscorelib2.blocks.BlockPosition;
 import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
@@ -33,6 +34,7 @@ public class MassFabricator extends SlimefunItem implements InventoryBlock, Ener
     public static final int ENERGY_CONSUMPTION = 16_666;
     public static final int CAPACITY = ENERGY_CONSUMPTION * 3;
 
+    private static final int[] BORDER = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
     private static final int[] INPUT_SLOTS = new int[] {10, 11};
     private static final int OUTPUT_SLOT = 15;
     private static final int PROGRESS_SLOT = 13;
@@ -56,15 +58,25 @@ public class MassFabricator extends SlimefunItem implements InventoryBlock, Ener
 
     private void setupInv() {
         createPreset(this, "&5Mass Fabricator", blockMenuPreset -> {
-            for (int i = 0; i < 27; i++)
+            for (int i : BORDER)
                 blockMenuPreset.addItem(i, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
-
-            for (int slot : INPUT_SLOTS)
-                blockMenuPreset.addItem(slot, null, (player, i, itemStack, clickAction) -> true);
 
             Utils.putOutputSlot(blockMenuPreset, OUTPUT_SLOT);
 
             blockMenuPreset.addItem(PROGRESS_SLOT, progressItem);
+            blockMenuPreset.addMenuClickHandler(PROGRESS_SLOT, ChestMenuUtils.getEmptyClickHandler());
+
+            registerBlockHandler(getId(), (p, b, stack, reason) -> {
+                BlockMenu inv = BlockStorage.getInventory(b);
+                Location location = b.getLocation();
+
+                if (inv != null) {
+                    inv.dropItems(location, getInputSlots());
+                    inv.dropItems(location, getOutputSlots());
+                }
+
+                return true;
+            });
         });
     }
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/MassFabricator.java
@@ -66,17 +66,7 @@ public class MassFabricator extends SlimefunItem implements InventoryBlock, Ener
             blockMenuPreset.addItem(PROGRESS_SLOT, progressItem);
             blockMenuPreset.addMenuClickHandler(PROGRESS_SLOT, ChestMenuUtils.getEmptyClickHandler());
 
-            registerBlockHandler(getId(), (p, b, stack, reason) -> {
-                BlockMenu inv = BlockStorage.getInventory(b);
-                Location location = b.getLocation();
-
-                if (inv != null) {
-                    inv.dropItems(location, getInputSlots());
-                    inv.dropItems(location, getOutputSlots());
-                }
-
-                return true;
-            });
+            Utils.registerInventoryDrop(getId(), this);
         });
     }
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/Recycler.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/Recycler.java
@@ -20,6 +20,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.cscorelib2.blocks.BlockPosition;
 import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -34,6 +35,7 @@ public class Recycler extends SlimefunItem implements InventoryBlock, EnergyNetC
     public static final int ENERGY_CONSUMPTION = 100;
     public static final int CAPACITY = 450;
 
+    private static final int[] BORDER = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26};
     private static final int INPUT_SLOT = 11;
     private static final int OUTPUT_SLOT = 15;
     private static final int PROGRESS_SLOT = 13;
@@ -54,13 +56,25 @@ public class Recycler extends SlimefunItem implements InventoryBlock, EnergyNetC
 
     private void setupInv() {
         createPreset(this, "&8Recycler", blockMenuPreset -> {
-            for (int i = 0; i < 27; i++)
+            for (int i : BORDER)
                 blockMenuPreset.addItem(i, ChestMenuUtils.getBackground(), ChestMenuUtils.getEmptyClickHandler());
 
-            blockMenuPreset.addItem(INPUT_SLOT, null, (player, i, itemStack, clickAction) -> true);
             Utils.putOutputSlot(blockMenuPreset, OUTPUT_SLOT);
 
             blockMenuPreset.addItem(PROGRESS_SLOT, new CustomItem(Material.DEAD_BUSH, "&7Progress"));
+            blockMenuPreset.addMenuClickHandler(PROGRESS_SLOT, ChestMenuUtils.getEmptyClickHandler());
+        });
+
+        registerBlockHandler(getId(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
+            Location location = b.getLocation();
+
+            if (inv != null) {
+                inv.dropItems(location, getInputSlots());
+                inv.dropItems(location, getOutputSlots());
+            }
+
+            return true;
         });
     }
 

--- a/src/main/java/dev/j3fftw/litexpansion/machine/Recycler.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/Recycler.java
@@ -65,17 +65,7 @@ public class Recycler extends SlimefunItem implements InventoryBlock, EnergyNetC
             blockMenuPreset.addMenuClickHandler(PROGRESS_SLOT, ChestMenuUtils.getEmptyClickHandler());
         });
 
-        registerBlockHandler(getId(), (p, b, stack, reason) -> {
-            BlockMenu inv = BlockStorage.getInventory(b);
-            Location location = b.getLocation();
-
-            if (inv != null) {
-                inv.dropItems(location, getInputSlots());
-                inv.dropItems(location, getOutputSlots());
-            }
-
-            return true;
-        });
+        Utils.registerInventoryDrop(getId(), this);
     }
 
     @Override

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -5,9 +5,14 @@ import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.cscorelib2.chat.ChatColors;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -42,6 +47,20 @@ public final class Utils {
             public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
                 return cursor == null || cursor.getType() == null || cursor.getType() == Material.AIR;
             }
+        });
+    }
+
+    public static void registerInventoryDrop(String id, SlimefunItem item) {
+        SlimefunItem.registerBlockHandler(id, (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
+            Location location = b.getLocation();
+
+            if (inv != null) {
+                inv.dropItems(location, ((InventoryBlock) item).getInputSlots());
+                inv.dropItems(location, ((InventoryBlock) item).getOutputSlots());
+            }
+
+            return true;
         });
     }
 

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -31,7 +31,7 @@ public final class Utils {
     }
 
     public static void putOutputSlot(BlockMenuPreset preset, int slot) {
-        preset.addItem(slot, null, new ChestMenu.AdvancedMenuClickHandler() {
+        preset.addMenuClickHandler(slot, new ChestMenu.AdvancedMenuClickHandler() {
 
             @Override
             public boolean onClick(Player p, int slot, ItemStack cursor, ClickAction action) {
@@ -40,7 +40,7 @@ public final class Utils {
 
             @Override
             public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
-                return cursor == null || cursor.getType() == Material.AIR;
+                return cursor == null || cursor.getType() == null || cursor.getType() == Material.AIR;
             }
         });
     }

--- a/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
+++ b/src/main/java/dev/j3fftw/litexpansion/utils/Utils.java
@@ -50,6 +50,12 @@ public final class Utils {
         });
     }
 
+    /**
+     * Adds a block break handler onto machines so that
+     * the inventory is dropped when the block is broken
+     * @param id specifies the id of the block
+     * @param item specifies the SlimefunItem to be modified
+     */
     public static void registerInventoryDrop(String id, SlimefunItem item) {
         SlimefunItem.registerBlockHandler(id, (p, b, stack, reason) -> {
             BlockMenu inv = BlockStorage.getInventory(b);


### PR DESCRIPTION
## Short Description
Input and output slots are no longer wiped when the server restarts, machines drop inventory when broken

## Additions/Changes/Removals
- Fixed preset so that the input and output slots are no longer wiped when the server restarts
- Added block handler so that they drop input/outputs when broken

## Related Issues
Issue that has been bugging ppl for a while, seen here and there on discord.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
