### PR TITLE
fix stack size stuff

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
+++ b/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
@@ -130,7 +130,7 @@ final class ItemSetup {
 
         registerNonPlaceableItem(Items.TIN_ITEM_CASING, ManualMill.RECIPE_TYPE, Items.TIN_PLATE);
 
-        registerNonPlaceableItem(new SlimefunItemStack(Items.UNINSULATED_TIN_CABLE, 3),
+        registerNonPlaceableItem(Items.UNINSULATED_TIN_CABLE, 3,
             ManualMill.RECIPE_TYPE, Items.TIN_ITEM_CASING
         );
 
@@ -142,7 +142,7 @@ final class ItemSetup {
 
         registerNonPlaceableItem(Items.COPPER_ITEM_CASING, ManualMill.RECIPE_TYPE, Items.COPPER_PLATE);
 
-        registerNonPlaceableItem(new SlimefunItemStack(Items.UNINSULATED_COPPER_CABLE, 3),
+        registerNonPlaceableItem(Items.UNINSULATED_COPPER_CABLE, 3,
             ManualMill.RECIPE_TYPE, Items.COPPER_ITEM_CASING
         );
 
@@ -159,7 +159,7 @@ final class ItemSetup {
 
         registerNonPlaceableItem(Items.GOLD_ITEM_CASING, ManualMill.RECIPE_TYPE, Items.GOLD_PLATE);
 
-        registerNonPlaceableItem(new SlimefunItemStack(Items.UNINSULATED_GOLD_CABLE, 3),
+        registerNonPlaceableItem(Items.UNINSULATED_GOLD_CABLE, 3,
             ManualMill.RECIPE_TYPE, Items.GOLD_ITEM_CASING
         );
 
@@ -311,7 +311,7 @@ final class ItemSetup {
         new SlimefunItem(Items.LITEXPANSION, result, type, recipe).register(plugin);
     }
 
-    private void registerNonPlaceableItem(@Nonnull SlimefunItemStack result, @Nonnull RecipeType type,
+    private void registerNonPlaceableItem(@Nonnull SlimefunItemStack item, @Nonnull RecipeType type,
                                           @Nonnull ItemStack... items) {
         ItemStack[] recipe;
 
@@ -322,7 +322,24 @@ final class ItemSetup {
             recipe = items;
         }
 
-        new UnplaceableBlock(Items.LITEXPANSION, result, type, recipe).register(plugin);
+        new UnplaceableBlock(Items.LITEXPANSION, item, type, recipe).register(plugin);
+    }
+
+    /**
+     * Register an item with an output amount greater than 1
+     */
+    private void registerNonPlaceableItem(@Nonnull SlimefunItemStack item, int amount, @Nonnull RecipeType type,
+                                          @Nonnull ItemStack... items) {
+        ItemStack[] recipe;
+
+        if (items.length < 9) {
+            recipe = new ItemStack[9];
+            System.arraycopy(items, 0, recipe, 0, items.length);
+        } else {
+            recipe = items;
+        }
+
+        new UnplaceableBlock(Items.LITEXPANSION, item, type, recipe, new SlimefunItemStack(item, amount)).register(plugin);
     }
 
 

--- a/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
+++ b/src/main/java/dev/j3fftw/litexpansion/ItemSetup.java
@@ -313,16 +313,7 @@ final class ItemSetup {
 
     private void registerNonPlaceableItem(@Nonnull SlimefunItemStack item, @Nonnull RecipeType type,
                                           @Nonnull ItemStack... items) {
-        ItemStack[] recipe;
-
-        if (items.length < 9) {
-            recipe = new ItemStack[9];
-            System.arraycopy(items, 0, recipe, 0, items.length);
-        } else {
-            recipe = items;
-        }
-
-        new UnplaceableBlock(Items.LITEXPANSION, item, type, recipe).register(plugin);
+        registerNonPlaceableItem(item, 1, type, items);
     }
 
     /**


### PR DESCRIPTION
## Short Description
fixed the stack size error/complaints

## Additions/Changes/Removals
added a new method to register unpeaceable block with output amount greater than 1

## Related Issues
Resolves #16

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
