### PR TITLE
Saved new config options to config on startup

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
+++ b/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
@@ -17,7 +17,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import dev.j3fftw.litexpansion.service.MetricsService;
 
 import javax.annotation.Nonnull;
-import java.io.File;
 
 public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
 
@@ -29,9 +28,8 @@ public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
     public void onEnable() {
         setInstance(this);
 
-        if (!new File(getDataFolder(), "config.yml").exists()) {
-            saveDefaultConfig();
-        }
+        getConfig().options().copyDefaults(true);
+        saveConfig();
 
         final Metrics metrics = new Metrics(this, 7111);
         metricsService.setup(metrics);


### PR DESCRIPTION
## Short Description
Made it so any new config options will be automatically added to the config on startup

## Additions/Changes/Removals
enabled copy defaults and saved the config on startup

## Related Issues

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
