### PR TITLE
Fixes NoSuchMethodError

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/machine/extensions/CraftingMultiBlock.java
+++ b/src/main/java/dev/j3fftw/litexpansion/machine/extensions/CraftingMultiBlock.java
@@ -5,12 +5,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.libraries.paperlib.PaperLib;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import java.util.List;
-import javax.annotation.Nonnull;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.cscorelib2.inventory.ItemUtils;
 import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
@@ -24,6 +21,9 @@ import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.List;
 
 public abstract class CraftingMultiBlock extends MultiBlockMachine {
 
@@ -60,7 +60,7 @@ public abstract class CraftingMultiBlock extends MultiBlockMachine {
                 if (isCraftable(inv, input)) {
                     ItemStack output = RecipeType.getRecipeOutputList(this, input).clone();
 
-                    if (Slimefun.hasUnlocked(p, output, true)) {
+                    if (SlimefunUtils.canPlayerUseItem(p, output, true)) {
                         craft(inv, dispenser, p, b, output);
                     }
 


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This was done due to errors thrown from multiblock machines when attempting recipes

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
This change is to update the method from hasUnlocked to canPlayerUseItem

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #42 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
