### PR TITLE
Fix & Update Supreme Nerf

### DIFF
--- a/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
+++ b/src/main/java/dev/j3fftw/litexpansion/LiteXpansion.java
@@ -103,13 +103,18 @@ public class LiteXpansion extends JavaPlugin implements SlimefunAddon {
         Reflections.setField(SlimefunItem.getById("FUSION_REACTOR"), "energyProducedPerTick", 8_192);
 
         // SupremeExpansion - just no...
-        Reflections.setField(SlimefunItem.getById("SUPREME_GENERATOR"), "energyProducedPerTick", 20_000);
-        Reflections.setField(SlimefunItem.getById("THORNIUM_GENERATOR"), "energyProducedPerTick", 10_000);
-        Reflections.setField(SlimefunItem.getById("LUMIUM_GENERATOR"), "energyProducedPerTick", 5_000);
-        Reflections.setField(SlimefunItem.getById("LUX_GENERATOR"), "energyProducedPerTick", 2_500);
-        Reflections.setField(SlimefunItem.getById("AQUA_GENERATOR"), "energyProducedPerTick", 2_500);
-        Reflections.setField(SlimefunItem.getById("VENUS_GENERATOR"), "energyProducedPerTick", 2_500);
-        Reflections.setField(SlimefunItem.getById("IGNIS_GENERATOR"), "energyProducedPerTick", 2_500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_SUPREME_GENERATOR"), "energyProducedPerTick", 20_000);
+        Reflections.setField(SlimefunItem.getById("SUPREME_THORNIUM_GENERATOR"), "energyProducedPerTick", 10_000);
+        Reflections.setField(SlimefunItem.getById("SUPREME_LUMIUM_GENERATOR"), "energyProducedPerTick", 5_000);
+        Reflections.setField(SlimefunItem.getById("SUPREME_BASIC_LUMIUM_GENERATOR"), "energyProducedPerTick", 500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_LUX_GENERATOR"), "energyProducedPerTick", 2_500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_BASIC_LUX_GENERATOR"), "energyProducedPerTick", 250);
+        Reflections.setField(SlimefunItem.getById("SUPREME_AQUA_GENERATOR"), "energyProducedPerTick", 2_500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_BASIC_AQUA_GENERATOR"), "energyProducedPerTick", 250);
+        Reflections.setField(SlimefunItem.getById("SUPREME_VENUS_GENERATOR"), "energyProducedPerTick", 2_500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_BASIC_VENUS_GENERATOR"), "energyProducedPerTick", 250);
+        Reflections.setField(SlimefunItem.getById("SUPREME_IGNIS_GENERATOR"), "energyProducedPerTick", 2_500);
+        Reflections.setField(SlimefunItem.getById("SUPREME_BASIC_IGNIS_GENERATOR"), "energyProducedPerTick", 250);
     }
 
     private void setupResearches() {


### PR DESCRIPTION
## Short Description
This PR aims to fix and update the generator nerf for supreme.

## Additions/Changes/Removals
- Changed each of the lines for Supreme to prefix the id with `SUPREME_`
- Added a nerf to each of the basic versions of machines, it is 1/10 of the normal nerf, like how supreme does

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
